### PR TITLE
Fix LGTM alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Numbers/issues/90
+Your prepared branch: issue-90-bdd0703d
+Your prepared working directory: /tmp/gh-issue-solver-1757761936380
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Numbers/issues/90
-Your prepared branch: issue-90-bdd0703d
-Your prepared working directory: /tmp/gh-issue-solver-1757761936380
-
-Proceed.

--- a/csharp/Platform.Numbers/Bit[T].cs
+++ b/csharp/Platform.Numbers/Bit[T].cs
@@ -18,33 +18,74 @@ namespace Platform.Numbers
         private static int BitsSize = NumericType<T>.BitsSize;
 
         /// <summary>
-        /// 
+        /// <para>Writes a portion of the source value into the target value at the specified bit position.</para>
+        /// <para>Записывает часть исходного значения в целевое значение в указанной битовой позиции.</para>
         /// </summary>
-        /// <returns></returns>
+        /// <param name="target">
+        /// <para>The target value to write to.</para>
+        /// <para>Целевое значение для записи.</para>
+        /// </param>
+        /// <param name="source">
+        /// <para>The source value to read from.</para>
+        /// <para>Исходное значение для чтения.</para>
+        /// </param>
+        /// <param name="shift">
+        /// <para>The bit position to start writing at.</para>
+        /// <para>Битовая позиция для начала записи.</para>
+        /// </param>
+        /// <param name="limit">
+        /// <para>The number of bits to write.</para>
+        /// <para>Количество битов для записи.</para>
+        /// </param>
+        /// <returns>
+        /// <para>The target value with the specified bits updated.</para>
+        /// <para>Целевое значение с обновленными указанными битами.</para>
+        /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T PartialWrite(T target, T source, int shift, int limit)
         {
             if (shift < 0)
             {
-                shift = 32 + shift;
+                shift = BitsSize + shift;
             }
             if (limit < 0)
             {
-                limit = 32 + limit;
+                limit = BitsSize + limit;
             }
             var sourceMask = ~(T.MaxValue << limit) & T.MaxValue;
             var targetMask = ~(sourceMask << shift);
             return target & targetMask | (source & sourceMask) << shift;
         }
+        
+        /// <summary>
+        /// <para>Reads a portion of bits from the target value at the specified bit position.</para>
+        /// <para>Читает часть битов из целевого значения в указанной битовой позиции.</para>
+        /// </summary>
+        /// <param name="target">
+        /// <para>The target value to read from.</para>
+        /// <para>Целевое значение для чтения.</para>
+        /// </param>
+        /// <param name="shift">
+        /// <para>The bit position to start reading from.</para>
+        /// <para>Битовая позиция для начала чтения.</para>
+        /// </param>
+        /// <param name="limit">
+        /// <para>The number of bits to read.</para>
+        /// <para>Количество битов для чтения.</para>
+        /// </param>
+        /// <returns>
+        /// <para>The extracted bits as a value.</para>
+        /// <para>Извлеченные биты в виде значения.</para>
+        /// </returns>
         public static T PartialRead(T target, int shift, int limit)
         {
             if (shift < 0)
             {
-                shift = 32 + shift;
+                shift = BitsSize + shift;
             }
             if (limit < 0)
             {
-                limit = 32 + limit;
+                limit = BitsSize + limit;
             }
             var sourceMask = ~(T.MaxValue << limit) & T.MaxValue;
             var targetMask = sourceMask << shift;

--- a/csharp/Platform.Numbers/Math.cs
+++ b/csharp/Platform.Numbers/Math.cs
@@ -52,7 +52,7 @@ namespace Platform.Numbers
         /// </returns>
         public static TLinkAddress Factorial<TLinkAddress>(TLinkAddress n) where TLinkAddress : IUnsignedNumber<TLinkAddress>, IComparisonOperators<TLinkAddress, TLinkAddress, bool>
         {
-            if (n >= TLinkAddress.Zero && n <= TLinkAddress.CreateTruncating(MaximumCatalanIndex))
+            if (n >= TLinkAddress.Zero && n <= TLinkAddress.CreateTruncating(MaximumFactorialNumber))
             {
                 return TLinkAddress.CreateTruncating(_factorials[ulong.CreateTruncating(n)]);
             }
@@ -101,7 +101,7 @@ namespace Platform.Numbers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsPowerOfTwo<TLinkAddress>(TLinkAddress x) where TLinkAddress : IUnsignedNumber<TLinkAddress>, IBitwiseOperators<TLinkAddress, TLinkAddress, TLinkAddress>, IComparisonOperators<TLinkAddress, TLinkAddress, bool>
         {
-            return (x & x - TLinkAddress.One) == TLinkAddress.Zero;
+            return x > TLinkAddress.Zero && (x & (x - TLinkAddress.One)) == TLinkAddress.Zero;
         }
     }
 }

--- a/csharp/Platform.Numbers/Platform.Numbers.csproj
+++ b/csharp/Platform.Numbers/Platform.Numbers.csproj
@@ -4,7 +4,7 @@
     <Description>LinksPlatform's Platform.Numbers Class Library</Description>
     <Copyright>Konstantin Diachenko</Copyright>
     <AssemblyTitle>Platform.Numbers</AssemblyTitle>
-    <VersionPrefix>0.9.0</VersionPrefix>
+    <VersionPrefix>0.9.1</VersionPrefix>
     <Authors>Konstantin Diachenko</Authors>
     <TargetFramework>net8</TargetFramework>
     <AssemblyName>Platform.Numbers</AssemblyName>
@@ -23,7 +23,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <LangVersion>latest</LangVersion>
-    <PackageReleaseNotes>Update target framework from net7 to net8.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fix LGTM alerts: add missing XML documentation, fix hardcoded bit size constants, fix IsPowerOfTwo method for zero values, fix incorrect MaximumCatalanIndex usage in Factorial method.</PackageReleaseNotes>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

This PR fixes several LGTM alerts identified in issue #90:

- **Missing XML documentation**: Added comprehensive XML documentation for `Bit<T>.PartialRead` method
- **Hardcoded constants**: Replaced hardcoded bit size constants (`32`) with the `BitsSize` field for better type safety and correctness
- **Potential overflow bug**: Fixed `IsPowerOfTwo` method to correctly handle zero values (zero is not a power of two) 
- **Logic error**: Fixed incorrect usage of `MaximumCatalanIndex` in `Factorial` method, should use `MaximumFactorialNumber`

## Test plan

- [x] All existing tests pass
- [x] Build succeeds without warnings
- [x] Version updated to 0.9.1 with appropriate release notes

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #90