### PR TITLE
Keep Factorial method and add tests to verify precalculated constants

### DIFF
--- a/csharp/Platform.Numbers.Tests/MathTests.cs
+++ b/csharp/Platform.Numbers.Tests/MathTests.cs
@@ -32,13 +32,22 @@ namespace Platform.Numbers.Tests
         private static BigInteger? ComputeCatalanWithTimeLimit(ulong n)
         {
             var twoNFact = ComputeFactorialWithTimeLimit(2 * n);
-            if (twoNFact is null) return null;
+            if (twoNFact is null)
+            {
+                return null;
+            }
 
             var nPlusOneFact = ComputeFactorialWithTimeLimit(n + 1);
-            if (nPlusOneFact is null) return null;
+            if (nPlusOneFact is null)
+            {
+                return null;
+            }
 
             var nFact = ComputeFactorialWithTimeLimit(n);
-            if (nFact is null) return null;
+            if (nFact is null)
+            {
+                return null;
+            }
 
             return twoNFact / (nPlusOneFact * nFact);
         }

--- a/csharp/Platform.Numbers.Tests/MathTests.cs
+++ b/csharp/Platform.Numbers.Tests/MathTests.cs
@@ -1,10 +1,52 @@
 using System;
+using System.Diagnostics;
+using System.Numerics;
 using Xunit;
 
 namespace Platform.Numbers.Tests
 {
     public static class MathTests
     {
+        private static readonly TimeSpan ComputationTimeLimit = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Computes factorial of n using BigInteger so it never overflows.
+        /// Returns null if computation exceeds the time limit.
+        /// </summary>
+        private static BigInteger? ComputeFactorialWithTimeLimit(ulong n)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            BigInteger result = BigInteger.One;
+            for (ulong i = 2; i <= n; i++)
+            {
+                result *= i;
+                if (stopwatch.Elapsed > ComputationTimeLimit)
+                {
+                    return null;
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Computes the nth Catalan number from scratch using the formula:
+        /// C(n) = (2n)! / ((n+1)! * n!)
+        /// Returns null if computation exceeds the time limit.
+        /// </summary>
+        private static BigInteger? ComputeCatalanWithTimeLimit(ulong n)
+        {
+            var twoNFact = ComputeFactorialWithTimeLimit(2 * n);
+            if (twoNFact is null) return null;
+
+            var nPlusOneFact = ComputeFactorialWithTimeLimit(n + 1);
+            if (nPlusOneFact is null) return null;
+
+            var nFact = ComputeFactorialWithTimeLimit(n);
+            if (nFact is null) return null;
+
+            return twoNFact / (nPlusOneFact * nFact);
+        }
+
         [Theory]
         [InlineData(0ul, 1ul)]
         [InlineData(1ul, 1ul)]
@@ -106,6 +148,47 @@ namespace Platform.Numbers.Tests
         {
             Assert.Equal(20ul, Math.MaximumFactorialNumber);
             Assert.Equal(36ul, Math.MaximumCatalanIndex);
+        }
+
+        [Fact]
+        public static void PrecalculatedFactorialsMatchComputedValues()
+        {
+            // Verify that every precalculated factorial constant in Math._factorials is actually
+            // a correct factorial value, computed independently using BigInteger arithmetic.
+            // Only computes values that finish within 10 seconds; larger values would need
+            // verification via an external trusted resource (e.g. OEIS A000142: https://oeis.org/A000142).
+            for (ulong n = 0; n <= Math.MaximumFactorialNumber; n++)
+            {
+                var computed = ComputeFactorialWithTimeLimit(n);
+                if (computed is null)
+                {
+                    // Computation exceeded 10 seconds — skip and rely on external verification.
+                    continue;
+                }
+                var precalculated = Math.Factorial<ulong>(n);
+                Assert.Equal((ulong)computed, precalculated);
+            }
+        }
+
+        [Fact]
+        public static void PrecalculatedCatalansMatchComputedFactorials()
+        {
+            // Verify that every precalculated Catalan constant in Math._catalans is actually
+            // a correct Catalan number, computed from scratch using the formula:
+            //   C(n) = (2n)! / ((n+1)! * n!)
+            // Only computes values that finish within 10 seconds; larger values would need
+            // verification via an external trusted resource (e.g. OEIS A000108: https://oeis.org/A000108).
+            for (ulong n = 0; n <= Math.MaximumCatalanIndex; n++)
+            {
+                var computed = ComputeCatalanWithTimeLimit(n);
+                if (computed is null)
+                {
+                    // Computation exceeded 10 seconds — skip and rely on external verification.
+                    continue;
+                }
+                var precalculated = Math.Catalan<ulong>(n);
+                Assert.Equal((ulong)computed, precalculated);
+            }
         }
     }
 }

--- a/csharp/Platform.Numbers.Tests/MathTests.cs
+++ b/csharp/Platform.Numbers.Tests/MathTests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net.Http;
 using System.Numerics;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace Platform.Numbers.Tests
@@ -8,6 +11,39 @@ namespace Platform.Numbers.Tests
     public static class MathTests
     {
         private static readonly TimeSpan ComputationTimeLimit = TimeSpan.FromSeconds(10);
+        private static readonly HttpClient HttpClient = new();
+
+        // Fetches all entries from an OEIS b-file (plain text format: "n value" per line).
+        // Returns a dictionary mapping index -> value as BigInteger.
+        // The b-file URL format is: https://oeis.org/AXXXXXX/b000XXX.txt
+        private static Dictionary<ulong, BigInteger> FetchOeisSequence(string bFileUrl)
+        {
+            var result = new Dictionary<ulong, BigInteger>();
+            string content = HttpClient.GetStringAsync(bFileUrl).GetAwaiter().GetResult();
+            foreach (var line in content.Split('\n'))
+            {
+                var trimmed = line.Trim();
+                if (trimmed.StartsWith("#") || trimmed.Length == 0)
+                {
+                    continue;
+                }
+                var parts = Regex.Split(trimmed, @"\s+");
+                if (parts.Length >= 2 && ulong.TryParse(parts[0], out var index) && BigInteger.TryParse(parts[1], out var value))
+                {
+                    result[index] = value;
+                }
+            }
+            return result;
+        }
+
+        // Lazily-fetched OEIS sequences, cached for the lifetime of the test run.
+        private static Dictionary<ulong, BigInteger>? _oeisFactorials;
+        private static Dictionary<ulong, BigInteger> OeisFactorials =>
+            _oeisFactorials ??= FetchOeisSequence("https://oeis.org/A000142/b000142.txt");
+
+        private static Dictionary<ulong, BigInteger>? _oeisCatalans;
+        private static Dictionary<ulong, BigInteger> OeisCatalans =>
+            _oeisCatalans ??= FetchOeisSequence("https://oeis.org/A000108/b000108.txt");
 
         // Computes factorial of n using BigInteger so it never overflows.
         // Returns null if computation exceeds the time limit.
@@ -159,19 +195,25 @@ namespace Platform.Numbers.Tests
         public static void PrecalculatedFactorialsMatchComputedValues()
         {
             // Verify that every precalculated factorial constant in Math._factorials is actually
-            // a correct factorial value, computed independently using BigInteger arithmetic.
-            // Only computes values that finish within 10 seconds; larger values would need
-            // verification via an external trusted resource (e.g. OEIS A000142: https://oeis.org/A000142).
+            // a correct factorial value. For values that can be computed locally within 10 seconds,
+            // an independent BigInteger computation is used. For values that take longer, the
+            // expected value is fetched from OEIS A000142 (https://oeis.org/A000142) via HTTP.
             for (ulong n = 0; n <= Math.MaximumFactorialNumber; n++)
             {
                 var computed = ComputeFactorialWithTimeLimit(n);
+                BigInteger expected;
                 if (computed is null)
                 {
-                    // Computation exceeded 10 seconds — skip and rely on external verification.
-                    continue;
+                    // Computation exceeded 10 seconds — verify against OEIS A000142.
+                    Assert.True(OeisFactorials.TryGetValue(n, out expected),
+                        $"OEIS A000142 did not contain a value for n={n}");
+                }
+                else
+                {
+                    expected = computed.Value;
                 }
                 var precalculated = Math.Factorial<ulong>(n);
-                Assert.Equal((ulong)computed, precalculated);
+                Assert.Equal((ulong)expected, precalculated);
             }
         }
 
@@ -179,20 +221,26 @@ namespace Platform.Numbers.Tests
         public static void PrecalculatedCatalansMatchComputedFactorials()
         {
             // Verify that every precalculated Catalan constant in Math._catalans is actually
-            // a correct Catalan number, computed from scratch using the formula:
-            //   C(n) = (2n)! / ((n+1)! * n!)
-            // Only computes values that finish within 10 seconds; larger values would need
-            // verification via an external trusted resource (e.g. OEIS A000108: https://oeis.org/A000108).
+            // a correct Catalan number. For values that can be computed locally within 10 seconds
+            // using the formula C(n) = (2n)! / ((n+1)! * n!), an independent BigInteger computation
+            // is used. For values that take longer, the expected value is fetched from OEIS A000108
+            // (https://oeis.org/A000108) via HTTP.
             for (ulong n = 0; n <= Math.MaximumCatalanIndex; n++)
             {
                 var computed = ComputeCatalanWithTimeLimit(n);
+                BigInteger expected;
                 if (computed is null)
                 {
-                    // Computation exceeded 10 seconds — skip and rely on external verification.
-                    continue;
+                    // Computation exceeded 10 seconds — verify against OEIS A000108.
+                    Assert.True(OeisCatalans.TryGetValue(n, out expected),
+                        $"OEIS A000108 did not contain a value for n={n}");
+                }
+                else
+                {
+                    expected = computed.Value;
                 }
                 var precalculated = Math.Catalan<ulong>(n);
-                Assert.Equal((ulong)computed, precalculated);
+                Assert.Equal((ulong)expected, precalculated);
             }
         }
     }

--- a/csharp/Platform.Numbers.Tests/MathTests.cs
+++ b/csharp/Platform.Numbers.Tests/MathTests.cs
@@ -9,10 +9,8 @@ namespace Platform.Numbers.Tests
     {
         private static readonly TimeSpan ComputationTimeLimit = TimeSpan.FromSeconds(10);
 
-        /// <summary>
-        /// Computes factorial of n using BigInteger so it never overflows.
-        /// Returns null if computation exceeds the time limit.
-        /// </summary>
+        // Computes factorial of n using BigInteger so it never overflows.
+        // Returns null if computation exceeds the time limit.
         private static BigInteger? ComputeFactorialWithTimeLimit(ulong n)
         {
             var stopwatch = Stopwatch.StartNew();
@@ -28,11 +26,9 @@ namespace Platform.Numbers.Tests
             return result;
         }
 
-        /// <summary>
-        /// Computes the nth Catalan number from scratch using the formula:
-        /// C(n) = (2n)! / ((n+1)! * n!)
-        /// Returns null if computation exceeds the time limit.
-        /// </summary>
+        // Computes the nth Catalan number from scratch using the formula:
+        // C(n) = (2n)! / ((n+1)! * n!)
+        // Returns null if computation exceeds the time limit.
         private static BigInteger? ComputeCatalanWithTimeLimit(ulong n)
         {
             var twoNFact = ComputeFactorialWithTimeLimit(2 * n);


### PR DESCRIPTION
## Summary

Based on feedback on this PR, the `Factorial` method should be kept so we can always verify that our precalculated constants are really correct factorials.

This PR adds tests that:
- Independently compute factorial values using BigInteger arithmetic (no overflow)
- Verify all precalculated `_factorials` constants match the computed values
- Independently compute Catalan numbers using the formula `C(n) = (2n)! / ((n+1)! * n!)`
- Verify all precalculated `_catalans` constants match the computed values
- For values whose local computation exceeds 10 seconds, make real HTTP requests to OEIS to fetch and verify the expected value:
  - Factorials: [OEIS A000142](https://oeis.org/A000142) (`https://oeis.org/A000142/b000142.txt`)
  - Catalan numbers: [OEIS A000108](https://oeis.org/A000108) (`https://oeis.org/A000108/b000108.txt`)

In practice, all values for `n ≤ 36` (the current `MaximumCatalanIndex`) compute locally in under 1ms — but the OEIS fallback ensures correctness even if the range is extended in future.

## Test Plan

- [x] `PrecalculatedFactorialsMatchComputedValues` — verifies all 21 factorial constants (0! through 20!) match independently computed BigInteger values; falls back to OEIS A000142 via HTTP if computation exceeds 10s
- [x] `PrecalculatedCatalansMatchComputedFactorials` — verifies all 37 Catalan constants (C(0) through C(36)) match independently computed BigInteger values; falls back to OEIS A000108 via HTTP if computation exceeds 10s
- [x] All existing tests continue to pass
- [x] Build succeeds with no errors

Fixes #59

🤖 Generated with [Claude Code](https://claude.ai/code)